### PR TITLE
Add workflow tweaks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  
+  "image": "islandc/armcm-devcontainer"
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       
 jobs:
   build:
-    runs-on: debian-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ fp-info-cache
 # Exported BOM files
 #*.xml
 #*.csv
+
+# Intermediate firmware files 
+firmware/build/*

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -219,7 +219,7 @@ clean:
 	-rm -fR $(BUILD_DIR)
 
 program: $(BUILD_DIR)/$(TARGET).bin | $(BUILD_DIR)
- 	dfu-util -a 0 -D $(BUILD_DIR)/$(TARGET).bin -s 0x08000000
+	dfu-util -a 0 -D $(BUILD_DIR)/$(TARGET).bin -s 0x08000000
 
   
 #######################################

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -217,6 +217,10 @@ $(BUILD_DIR):
 #######################################
 clean:
 	-rm -fR $(BUILD_DIR)
+
+program: $(BUILD_DIR)/$(TARGET).bin | $(BUILD_DIR)
+ 	dfu-util -a 0 -D $(BUILD_DIR)/$(TARGET).bin -s 0x08000000
+
   
 #######################################
 # dependencies


### PR DESCRIPTION
* Add the build outputs to the git ignore list.
* Add a build container image with `arm-none-eabi` build tools installed. This allows the code to be worked on and compiled online in GitHub codespaces.
* Add a make recipe `make program` to program via `dfu-util` when working locally.